### PR TITLE
Converting https

### DIFF
--- a/src/pt/arquivo/httrack2arc/controller/LogReader.java
+++ b/src/pt/arquivo/httrack2arc/controller/LogReader.java
@@ -169,7 +169,7 @@ public class LogReader {
 					LogEntry entry = new LogEntry();
 
 					String url = match.group(LogColumn.URL.position());
-					if ( !url.startsWith("http://") && !url.startWith("https://"))
+					if ( !url.startsWith("http://") && !url.startsWith("https://"))
 						url = "http://" + url;
 					entry.setUrl( url );
 					entry.setLocal( match.group(LogColumn.NO_DATE_LOCAL.position()) );

--- a/src/pt/arquivo/httrack2arc/controller/LogReader.java
+++ b/src/pt/arquivo/httrack2arc/controller/LogReader.java
@@ -127,7 +127,7 @@ public class LogReader {
 					LogEntry entry = new LogEntry();
 
 					String url = match.group(LogColumn.URL.position());
-					if ( !url.startsWith("http://") )
+					if ( !url.startsWith("http://") && !url.startsWith("https://"))
 						url = "http://" + url;
 					entry.setUrl( url );
 					entry.setLocal( match.group(LogColumn.LOCAL.position()) );
@@ -169,7 +169,7 @@ public class LogReader {
 					LogEntry entry = new LogEntry();
 
 					String url = match.group(LogColumn.URL.position());
-					if ( !url.startsWith("http://") )
+					if ( !url.startsWith("http://") && !url.startWith("https://"))
 						url = "http://" + url;
 					entry.setUrl( url );
 					entry.setLocal( match.group(LogColumn.NO_DATE_LOCAL.position()) );

--- a/src/pt/arquivo/httrack2arc/controller/RecursiveCrawlExporter.java
+++ b/src/pt/arquivo/httrack2arc/controller/RecursiveCrawlExporter.java
@@ -203,7 +203,7 @@ public class RecursiveCrawlExporter implements Exporter {
 					
 					
 					if ( !http ) {
-						pos = filename.substring("https:/");
+						pos = filename.indexOf("https:/");
 						if ( pos != -1) {
 							filename = filename.substring(pos);
 						}

--- a/src/pt/arquivo/httrack2arc/controller/RecursiveCrawlExporter.java
+++ b/src/pt/arquivo/httrack2arc/controller/RecursiveCrawlExporter.java
@@ -194,10 +194,20 @@ public class RecursiveCrawlExporter implements Exporter {
 					
 					// Extract the URL from the file path
 					String filename = child.getAbsolutePath();
+					boolean http = false;
 					int pos = filename.indexOf("http:/");
 					if ( pos != -1) {
 						filename = filename.substring(pos);
+						http = true;
 					}
+					
+					
+					if ( !http ) {
+						pos = filename.substring("https:/");
+						if ( pos != -1) {
+							filename = filename.substring(pos);
+						}
+					}	
 					String cacheEntry = filename.replaceFirst("/", "//");
 
 					for (LogEntry logEntry : metadata) {


### PR DESCRIPTION
Hey there,

as announced I'm finally doing my pull request.
As you can see here we first just changed a few lines in the RecursiveCrawlExporter and the LogReader so https-sites were not ignored.

Still if you run the Converter like this with a Httrack crawl that includes both http and https folders in its hts-cache folder it does **not** work because apparently the new.zip (or analogously the old.zip) are not accepted as directory, it appears: 
In pt.arquivo.httrack2arc.controller.RecursiveCrawlExporter in processCache(...) (#186) the if (cache.isDirectory) is never entered. 

We tried around a bit and it seems the problem might be that truezip does not accept certain files because of their dates. We changed some lines in the truezip-6.8.2:
in de.schlichtherle.util.zip.BasicZipFile in method mountCentralDirectory( ... ) in #478 
we replaced: 
 entry.setDosTime( LittleEndian.readUInt(cfh, off) );

with
 long dostim = LittleEndian.readUInt(cfh, off);
  System.out.println( "    dostim " +dostim );

   if ( dostim < 0x300000 )  {
     dostim = 0x300001;
     System.out.println("dostim < " +0x300000+ "  " +entry.getName());
   }
   entry.setDosTime( dostim );

With those adaptations the files are accepted an converted to arc.gz. 
But we are not yet sure if the output is exactly what it should be...

Still I wanted to at least make you aware of what we are working on right now.

I'd be grateful for any feedback if you have the time...
Annabel
